### PR TITLE
Change "More like" to a plugin, simplify include

### DIFF
--- a/_includes/moreLike.html
+++ b/_includes/moreLike.html
@@ -1,33 +1,13 @@
 <p>{{include.title}}</p>
 <table id="MorePostsTable">
-  
-    {% assign titles = page.title %}
-    {% assign length = 0 %}
     <tr>
-    {% for post in site.posts limit:{{include.limit | 4}} %}
-      {% if titles contains post.title %}
-      {% else if length <= 3 %}
-        <td class="linkToPage"><a href="{{ post.url }}">{{ post.title }}</a><br>{{post.descritption}}</td>
-        {% assign titles = titles | append: post.title %}
-        {% assign length = length | plus: 1 %}
-      {% endif %}      
-    {% endfor %} 
+        {% for post in page.posts_recent %}
+        <td class="linkToPage"><a href="{{ post.url }}">{{ post.title }}</a><br>{{post.description}}</td>
+        {% endfor %}
     </tr>
     <tr>
-    {% assign length = 0 %}
-    {% for tag in site.tags %}
-      {% capture tag_name %}{{ tag | first }}{% endcapture %}
-    
-      {% if page.tags contains tag_name %}
-        {% for post in site.tags[tag_name] %}
-            {% if titles contains post.title %}
-            {% else if length <= 3 %}
-              <td class="linkToPage"><a href="{{ post.url }}">{{ post.title }}</a><br>{{post.descritption}}</td>
-              {% assign titles = titles | append: post.title %}
-              {% assign length = length | plus: 1 %}
-            {% endif %}
+        {% for post in page.posts_like_tags %}
+        <td class="linkToPage"><a href="{{ post.url }}">{{ post.title }}</a><br>{{post.description}}</td>
         {% endfor %}
-      {% endif %}
-    {% endfor %} 
     </tr>
 </table>

--- a/_plugins/post-more-like.rb
+++ b/_plugins/post-more-like.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+#
+# TODO
+#
+
+class PostMoreLike < Jekyll::Generator
+  # TODO: remove own post; make this actually useful (randomised, multiple tags?
+  #       I dunno)
+  def generate(site)
+    max_related_posts = 3
+
+    site.posts.docs.each do |post|
+      first_tag = post.data["tags"][0]
+
+      # get at most max_related_posts (if fewer, take fewer)
+      posts_related_by_tag = site.tags[first_tag].take(max_related_posts)
+
+      # add to post frontmatter
+      post.data.merge!("posts_like_tags" => posts_related_by_tag)
+    end
+  end
+end


### PR DESCRIPTION
Working example of a "More like this" plugin. Currently searches for posts matching the first tag of a post -- not hugely useful, but should be clear how to extend it.